### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,4 +1,6 @@
 name: Pylint
+permissions:
+  contents: read
 
 on: [push]
 


### PR DESCRIPTION
Potential fix for [https://github.com/geeknik/mmm/security/code-scanning/1](https://github.com/geeknik/mmm/security/code-scanning/1)

To resolve the problem, we need to explicitly limit the permissions for the workflow in `.github/workflows/pylint.yml`. The best way to do this is to add a `permissions` block at the top level—right after `name` and before `on` (following YAML and GitHub Actions conventions). Since the workflow does not interact with the repository in ways that require broad privileges, the minimal required permission is `contents: read`. This change makes privilege intent explicit, improves security posture, and future-proofs the workflow.

**Summary of changes:**  
- Insert the following block after the `name: Pylint` line (before `on:`):  
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports, definitions, or code logic needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
