### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/mmm/preserving_sanitizer.py
+++ b/mmm/preserving_sanitizer.py
@@ -109,7 +109,7 @@ def preserving_sanitize(
         )
     except Exception as e:
         print(f"   ❌ Failed to load audio: {e}")
-        return {"success": False, "error": str(e)}
+        return {"success": False, "error": "Failed to load audio."}
 
     # Phase 2: PRESERVING threat neutralization
     print("🎵 Phase 2: PRESERVING threat neutralization...")
@@ -328,7 +328,7 @@ def preserving_sanitize(
         print(f"   ✅ Saved in {save_time:.2f}s")
     except Exception as e:
         print(f"   ❌ Failed to save: {e}")
-        return {"success": False, "error": str(e)}
+        return {"success": False, "error": "Failed to save sanitized audio."}
 
     total_time = time.time() - start_time
 


### PR DESCRIPTION
Potential fix for [https://github.com/geeknik/mmm/security/code-scanning/3](https://github.com/geeknik/mmm/security/code-scanning/3)

To fix this class of issue, never propagate raw exception objects/messages to client-facing data structures. Return a generic, user-safe error message from lower-level processing code, and keep detailed exception info only in server-side logs.

Best single fix (without changing existing functionality): edit `mmm/preserving_sanitizer.py` at the two shown exception return points so they no longer return `str(e)`. Keep the existing `print(...)` diagnostics (or replace with logging elsewhere if desired), but sanitize the returned `"error"` field to a constant generic message. This removes the taint source that reaches `server.py` and should address all listed alert variants in one change.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
